### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: elgohr/Publish-Docker-Github-Action@v4
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       name: Publish to Docker
       with:
         name: innovaciongascaribe/kubectl


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore